### PR TITLE
Fixing typo in githubquery from 'Githubh' to 'Github'

### DIFF
--- a/jirahub/githubquery.py
+++ b/jirahub/githubquery.py
@@ -34,7 +34,7 @@ class GithubQuery(object):
         if key:
             self.github = Github(key)
         elif user is not None:
-            self.github = Githubh(user, password)
+            self.github = Github(user, password)
         else:
             self.github = Github()
 
@@ -77,4 +77,3 @@ class GithubQuery(object):
             Status to change the comment to
         """
         self.issue.edit(state=status)
-


### PR DESCRIPTION
To fix Issue #14 

I still can't connect to GitHub this way to confirm that it works since it also needs 2-factor, but it doesn't give an error that 'Githubh' is not defined.