### PR TITLE
Escape strings from Jira content that look like GitHub user mentions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+0.2.2 (2020-08-10)
+------------------
+
+- Escape strings from Jira that would be interpreted by GitHub
+  as user mentions. [#26]
+
 0.2.1 (2020-06-25)
 ------------------
 

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -540,6 +540,10 @@ class TestFormatter:
                 "This is a link to a GitHub user profile: @username123",
             ),
             (
+                "This looks like a GitHub user mention but should be escaped: @username123",
+                "This looks like a GitHub user mention but should be escaped: @\u2063username123",
+            ),
+            (
                 "This is a body with *bold*, _italic_, and {{monospaced}} text.",
                 "This is a body with **bold**, *italic*, and `monospaced` text.",
             ),


### PR DESCRIPTION
This PR adds an invisible character between `@` and `username` in strings from Jira that would otherwise be interpreted by GitHub as user mentions.