### PR TITLE
Allow hyphens in GitHub usernames

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+0.2.3 (unreleased)
+------------------
+
+- Allow hyphens in GitHub usernames. [#27]
+
 0.2.2 (2020-08-10)
 ------------------
 

--- a/jirahub/github.py
+++ b/jirahub/github.py
@@ -331,7 +331,7 @@ class Formatter:
     URL_WITH_TEXT_RE = re.compile(r"\[(.*?)\|(http.*?)\]")
     URL_RE = re.compile(r"(\s|^)\[?(http.*?)\]?(\s|$)")
     USER_MENTION_RE = re.compile(r"\[~(.+?)\]")
-    GITHUB_USER_MENTION_RE = re.compile(r"(^|\s)@(\w+?)\b")
+    GITHUB_USER_MENTION_RE = re.compile(r"(^|\s)@([0-9a-zA-Z-]+)\b")
 
     def __init__(self, config, url_helper, jira_client):
         self._config = config

--- a/jirahub/jira.py
+++ b/jirahub/jira.py
@@ -432,7 +432,7 @@ class Formatter:
     NOFORMAT_OPEN_RE = re.compile(r"```(\w*)")
     NOFORMAT_CLOSE_RE = re.compile(r"```")
     HASH_NUMBER_RE = re.compile(r"(^|\s)#([0-9]+)($|\s)")
-    USER_MENTION_RE = re.compile(r"(^|\s)@(\w+?)\b")
+    USER_MENTION_RE = re.compile(r"(^|\s)@([0-9a-zA-Z-]+)\b")
     ITALIC_RE = re.compile(r"(^|[^\w*])\*(\w(.*?\w)?)\*($|[^\w*])")
     BOLD_RE = re.compile(r"(^|\W)\*\*(\w(.*?\w)?)\*\*($|\W)")
     MONOSPACED_RE = re.compile(r"`(.+?)`")

--- a/tests/test_jira.py
+++ b/tests/test_jira.py
@@ -568,6 +568,10 @@ class TestFormatter:
                 "This is a body with a GitHub mention: [Test User 123|https://github.com/username123]",
             ),
             (
+                "This is a body with a GitHub mention: @username-with-hyphens",
+                "This is a body with a GitHub mention: [Hyphen Aficionado|https://github.com/username-with-hyphens]",
+            ),
+            (
                 "This is a body with a GitHub mention that doesn't exist: @missing",
                 "This is a body with a GitHub mention that doesn't exist: @missing",
             ),
@@ -658,6 +662,7 @@ This is a single line quote
     )
     def test_format_body(self, formatter, body, expected, github_client, create_issue):
         github_client.users.append(User(Source.GITHUB, "username123", "Test User 123"))
+        github_client.users.append(User(Source.GITHUB, "username-with-hyphens", "Hyphen Aficionado"))
         github_client.issues.append(create_issue(Source.GITHUB, issue_id=2))
         github_client.pull_request_ids.append(4)
 


### PR DESCRIPTION
The regex for GitHub usernames needed a little tweaking